### PR TITLE
I've refactored the user registration and verification process.

### DIFF
--- a/endlessWorld/collage_nav/navigation/forms.py
+++ b/endlessWorld/collage_nav/navigation/forms.py
@@ -4,8 +4,6 @@ from django.contrib.auth import authenticate
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, Submit, Div, HTML
 from .models import CustomUser, Location
-import random
-import string
 
 class CustomUserRegistrationForm(UserCreationForm):
     email = forms.EmailField(required=True)
@@ -42,7 +40,7 @@ class CustomUserRegistrationForm(UserCreationForm):
         user.role = self.cleaned_data['role']
         
         # Generate verification token
-        user.verification_token = ''.join(random.choices(string.digits, k=6))
+        # user.verification_token = ''.join(random.choices(string.digits, k=6)) # Line removed as per new registration logic
         
         if commit:
             user.save()


### PR DESCRIPTION
Here are the changes for new user registration:
- You'll be marked as verified immediately upon registration.
- You'll receive a welcome SMS saying "Thanks for Register our app for navigation to CoICT collage" instead of a verification token.
- You'll be redirected to the login page after registration.
- The `verification_token` will no longer be generated or stored for new user registrations.

Regarding the verification token flow:
- The `verify_token_view` is now primarily for users who might have been created but not verified through other means (e.g., older accounts). It no longer sends a welcome SMS, as this is handled at registration.
- The password reset process remains unchanged and continues to use verification tokens.

I've also updated the tests:
- Tests for registration have been updated to reflect immediate verification, the new SMS message, and redirection.
- Tests for `verify_token_view` have been confirmed to be appropriate for its current scope.