### PR TITLE
feat: Enable admin drawing of navigation routes

### DIFF
--- a/endlessWorld/collage_nav/navigation/admin.py
+++ b/endlessWorld/collage_nav/navigation/admin.py
@@ -35,7 +35,7 @@ from django.utils import timezone # Needed for admin actions
 
 admin.site.register(CustomUser) # Kept for now
 # Location is handled by LocationAdmin
-admin.site.register(NavigationRoute) # Kept for now
+# admin.site.register(NavigationRoute) # Will be handled by NavigationRouteAdmin
 admin.site.register(UserSearch) # Kept for now
 admin.site.register(Geofence) # Kept for now
 admin.site.register(SMSAlert) # Kept for now
@@ -102,6 +102,13 @@ class LocationAdmin(gis_admin.GISModelAdmin): # Inherit from GISModelAdmin (OSMG
     default_lat = COICT_CENTER_LAT_ADMIN
     default_lon = COICT_CENTER_LON_ADMIN
     default_zoom = 16 # A bit more zoomed in for better detail initially
+
+@gis_admin.register(NavigationRoute)
+class NavigationRouteAdmin(gis_admin.GISModelAdmin):
+    list_display = ('route_id', 'source_location', 'destination_location', 'distance', 'estimated_time', 'is_accessible')
+    search_fields = ('source_location__name', 'destination_location__name')
+    list_filter = ('is_accessible', 'difficulty_level')
+    # route_path will automatically use the map widget from GISModelAdmin
 
 # @gis_admin.register(SMSAlert) # Use gis_admin if SMSAlert had GeoDjango fields, otherwise admin.register
 # class SMSAlertAdmin(admin.ModelAdmin): # If not a GeoDjango model, use admin.ModelAdmin


### PR DESCRIPTION
Integrates a map-based drawing interface for the `NavigationRoute` model in the Django admin panel.

Key changes:
- Modified `navigation/admin.py` to use `GISModelAdmin` for `NavigationRoute`.
- This allows administrators to manually draw the `route_path` (a LineString) on a map when creating or editing navigation routes.
- Configured `list_display`, `search_fields`, and `list_filter` for `NavigationRouteAdmin` to improve usability.

This change empowers administrators to define custom paths directly within the admin interface, enhancing the route management capabilities of the application.