### PR TITLE
feat: Implement manual route drawing on map

### DIFF
--- a/endlessWorld/collage_nav/navigation/templates/dashboard.html
+++ b/endlessWorld/collage_nav/navigation/templates/dashboard.html
@@ -166,6 +166,11 @@
                         <button class="btn btn-light" onclick="zoomIn()"><i class="fas fa-plus"></i></button>
                         <button class="btn btn-light" onclick="zoomOut()"><i class="fas fa-minus"></i></button>
                     </div>
+                    <!-- New Manual Drawing Buttons -->
+                    <button id="startDrawRouteBtn" class="btn btn-sm btn-info ms-2" onclick="startManualRouteDrawing()">Draw Route</button>
+                    <button id="finishDrawRouteBtn" class="btn btn-sm btn-success ms-2" onclick="finishManualRouteDrawing()">Finish Drawing</button>
+                    <button id="cancelDrawRouteBtn" class="btn btn-sm btn-warning ms-2" onclick="cancelManualRouteDrawing()">Cancel Drawing</button>
+                    <button id="clearAllRoutesBtn" class="btn btn-sm btn-danger ms-2" onclick="clearAllMapRoutes()">Clear All Routes</button>
                 </div>
             </div>
             <div class="card-body p-0" style="height: 600px; position: relative;"> <!-- Added position:relative for absolute child positioning -->


### PR DESCRIPTION
This feature allows you to manually draw a route on the map by clicking a series of points.

Key changes:
- I added JavaScript logic to `dashboard_map.js` to handle:
  - Starting, updating, finishing, and canceling manual route drawing.
  - Displaying the manually drawn route as a polyline.
  - Managing button states for drawing actions.
- I integrated manual route display with existing automatic route functionality:
  - Drawing a manual route clears any automatic route.
  - Fetching an automatic route clears any manual route.
  - A "Clear All Routes" button now clears both types of routes.
- I updated `dashboard.html` to include new UI buttons:
  - "Draw Route"
  - "Finish Drawing"
  - "Cancel Drawing"
  - "Clear All Routes"
- I ensured that pointer behavior and existing map interactions (search, auto-routing) remain consistent.
- All functionalities were analyzed.